### PR TITLE
Init DB without decorator

### DIFF
--- a/app.py
+++ b/app.py
@@ -21,9 +21,6 @@ def init_db():
     conn.close()
 
 
-@app.before_first_request
-def setup():
-    init_db()
 
 
 @app.route('/')
@@ -214,4 +211,5 @@ def meal_plan(pid):
 
 
 if __name__ == '__main__':
+    init_db()
     app.run(debug=True)


### PR DESCRIPTION
## Summary
- remove before_first_request `setup` wrapper
- initialize the database in the `__main__` block

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_684c8a1d535c832485cf2257ecc9c6c5