### PR TITLE
Init DB without decorator

### DIFF
--- a/app.py
+++ b/app.py
@@ -21,9 +21,6 @@ def init_db():
     conn.close()
 
 
-@app.before_first_request
-def setup():
-    init_db()
 
 
 @app.route('/')
@@ -129,11 +126,13 @@ def patient_detail(pid):
     patient = con.execute('SELECT * FROM patients WHERE id=?', (pid,)).fetchone()
     visits = con.execute('SELECT * FROM visits WHERE patient_id=? ORDER BY date DESC', (pid,)).fetchall()
     measures = con.execute('SELECT date, weight, waist, hip FROM visits WHERE patient_id=? ORDER BY date', (pid,)).fetchall()
+    goals = con.execute('SELECT * FROM obiettivi WHERE patient_id=?', (pid,)).fetchone()
     visit = None
     if vid:
         visit = con.execute('SELECT * FROM visits WHERE id=?', (vid,)).fetchone()
     con.close()
-    return render_template('patient_detail.html', patient=patient, visits=visits, visit=visit, measures=measures)
+    return render_template('patient_detail.html', patient=patient, visits=visits,
+                           visit=visit, measures=measures, goals=goals)
 
 
 @app.route('/patient/<int:pid>/visit', methods=['GET', 'POST'])
@@ -166,12 +165,6 @@ def new_visit(pid):
     return render_template('visit_form.html', today=date.today().isoformat(), last_notes=last_notes)
 
 
-@app.route('/patient/<int:pid>/visit/<int:vid>')
-def show_visit(pid, vid):
-    con = get_db()
-    visit = con.execute('SELECT * FROM visits WHERE id=?', (vid,)).fetchone()
-    con.close()
-    return render_template('patient_detail.html', patient={'id': pid}, visits=[], visit=visit, measures=[])
 
 
 @app.route('/patient/<int:pid>/visit/<int:vid>/edit', methods=['POST'])
@@ -214,4 +207,5 @@ def meal_plan(pid):
 
 
 if __name__ == '__main__':
+    init_db()
     app.run(debug=True)

--- a/templates/patient_detail.html
+++ b/templates/patient_detail.html
@@ -20,22 +20,37 @@
 <div class="col-md-8">
 <h4>Visite</h4>
 <table class="table table-sm">
-<tr><th>Data</th><th>Azioni</th></tr>
+<tr><th>Data</th></tr>
 {% for v in visits %}
 <tr>
-<td>{{v['date']}}</td>
-<td><a class="btn btn-sm btn-info" href="/patient/{{patient['id']}}/visit/{{v['id']}}">Mostra</a></td>
+<td><a href="/patient/{{patient['id']}}?visit={{v['id']}}">{{v['date']}}</a></td>
 </tr>
 {% endfor %}
 </table>
+<h4>Piano Nutrizionale</h4>
+{% if goals %}
+<ul class="list-unstyled">
+  <li>Calorie: {{ goals['calories'] }}</li>
+  <li>CHO %: {{ goals['cho_percent'] }}</li>
+  <li>PRO %: {{ goals['pro_percent'] }}</li>
+  <li>FAT %: {{ goals['fat_percent'] }}</li>
+</ul>
+{% else %}
+<p>Nessun obiettivo impostato</p>
+{% endif %}
+<a class="btn btn-sm btn-primary" href="/patient/{{patient['id']}}/meal_plan">Apri piano</a>
+</div>
+</div>
 {% if visit %}
+<div class="row mt-4">
+<div class="col">
 <h4>Dettaglio visita {{ visit['date'] }}</h4>
 <form method="post" action="/patient/{{patient['id']}}/visit/{{visit['id']}}/edit">
 <textarea name="notes" class="form-control" rows="10">{{ visit['notes'] }}</textarea>
 <button class="btn btn-primary mt-2" type="submit">Aggiorna</button>
 </form>
+</div>
+</div>
 {% endif %}
-</div>
-</div>
 <a class="btn btn-secondary mt-2" href="/">Indietro</a>
 {% endblock %}

--- a/templates/visit_form.html
+++ b/templates/visit_form.html
@@ -3,11 +3,18 @@
 <h1>Nuova visita</h1>
 <form method="post">
 <div class="mb-2"><label>Data</label><input type="date" name="date" class="form-control" value="{{today}}"></div>
-<h3>Note precedenti</h3>
-<div class="mb-3 border p-2">{{ last_notes|safe }}</div>
-<h3>Nuove note</h3>
-<div id="notes">
-<div class="mb-2"><input name="title1" class="form-control mb-1" placeholder="Titolo"><textarea name="desc1" class="form-control" placeholder="Descrizione"></textarea></div>
+<div class="row">
+  <div class="col-md-6">
+    <h3>Nuove note</h3>
+    <div id="notes">
+      <div class="mb-2"><input name="title1" class="form-control mb-1" placeholder="Titolo"><textarea name="desc1" class="form-control" placeholder="Descrizione"></textarea></div>
+    </div>
+    <button class="btn btn-sm btn-secondary mt-2" type="button" onclick="addNote()">Aggiungi nota</button>
+  </div>
+  <div class="col-md-6">
+    <h3>Note precedenti</h3>
+    <div class="mb-3 border p-2" style="min-height:100px;">{{ last_notes|safe }}</div>
+  </div>
 </div>
 <h3>Misure</h3>
 <div class="row g-2">
@@ -18,4 +25,15 @@
 <button class="btn btn-primary mt-2" type="submit">Salva</button>
 <a class="btn btn-secondary mt-2" href="/">Annulla</a>
 </form>
+<script>
+let noteIdx = 2;
+function addNote() {
+  const container = document.getElementById('notes');
+  const div = document.createElement('div');
+  div.className = 'mb-2';
+  div.innerHTML = `<input name="title${noteIdx}" class="form-control mb-1" placeholder="Titolo"><textarea name="desc${noteIdx}" class="form-control" placeholder="Descrizione"></textarea>`;
+  container.appendChild(div);
+  noteIdx++;
+}
+</script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- remove before_first_request `setup` wrapper
- initialize the database in the `__main__` block
- clean up patient detail view and show goals & meal plan
- show visit details inline and drop extra route
- allow adding multiple notes when creating a visit

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_684c8a1d535c832485cf2257ecc9c6c5