### PR TITLE
Init DB without decorator

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -9,5 +9,6 @@
 <div class="container mt-4">
     {% block content %}{% endblock %}
 </div>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
 </body>
 </html>

--- a/templates/goals_form.html
+++ b/templates/goals_form.html
@@ -1,0 +1,16 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>Obiettivi</h1>
+<form method="post">
+<div class="mb-2"><label class="form-label">Calorie</label>
+<input name="calories" class="form-control" type="number" value="{{ goals['calories'] if goals else '' }}" required></div>
+<div class="mb-2"><label class="form-label">CHO %</label>
+<input name="cho" class="form-control" type="number" step="0.1" value="{{ goals['cho_percent'] if goals else '' }}"></div>
+<div class="mb-2"><label class="form-label">PRO %</label>
+<input name="pro" class="form-control" type="number" step="0.1" value="{{ goals['pro_percent'] if goals else '' }}"></div>
+<div class="mb-2"><label class="form-label">FAT %</label>
+<input name="fat" class="form-control" type="number" step="0.1" value="{{ goals['fat_percent'] if goals else '' }}"></div>
+<button class="btn btn-primary" type="submit">Salva</button>
+<a class="btn btn-secondary" href="/patient/{{ patient_id }}">Annulla</a>
+</form>
+{% endblock %}

--- a/templates/meal_plan.html
+++ b/templates/meal_plan.html
@@ -14,29 +14,40 @@
 <div class="tab-pane fade {% if loop.first %}show active{% endif %}" id="tab{{loop.index}}">
 {% for meal in meals %}
 <h5>{{ meal }}</h5>
-<table class="table table-sm">
-<tr><th>Alimento</th><th>Gr</th><th>Kcal</th><th>CHO</th><th>PRO</th><th>FAT</th></tr>
+<table class="table table-sm" id="tbl_{{day}}_{{meal}}">
+<tr><th>Alimento</th><th>Gr</th><th>Kcal</th><th>CHO</th><th>PRO</th><th>FAT</th><th>Del</th></tr>
 {% for row in plan[(day,meal)] %}
 <tr>
-<td>{{ row['name'] }}</td>
-<td>{{ row['grams'] }}</td>
-<td>{{ row['kcal'] }}</td>
-<td>{{ row['carbs'] }}</td>
-<td>{{ row['protein'] }}</td>
-<td>{{ row['fat'] }}</td>
-</tr>
-{% endfor %}
-<tr>
-<td><select name="food_{{day}}_{{meal}}" class="form-select">
+<td><select name="food_{{row['id']}}" class="form-select food-select">
 <option value="">--</option>
 {% for food in foods %}
-<option value="{{food['id']}}">{{food['name']}}</option>
+<option value="{{food['id']}}" data-kcal="{{food['kcal']}}" data-carbs="{{food['carbs']}}" data-protein="{{food['protein']}}" data-fat="{{food['fat']}}" {% if food['id']==row['food_id'] %}selected{% endif %}>{{food['name']}}</option>
 {% endfor %}
 </select></td>
-<td><input name="gram_{{day}}_{{meal}}" class="form-control"></td>
-<td colspan="4"></td>
+<td><input name="gram_{{row['id']}}" type="number" class="form-control gram-input" value="{{row['grams']}}"></td>
+<td class="kcal"></td>
+<td class="carbs"></td>
+<td class="protein"></td>
+<td class="fat"></td>
+<td><input type="checkbox" name="del_{{row['id']}}"></td>
+</tr>
+{% endfor %}
+<tr class="new-row">
+<td><select name="new_food_{{day}}_{{meal}}_1" class="form-select food-select">
+<option value="">--</option>
+{% for food in foods %}
+<option value="{{food['id']}}" data-kcal="{{food['kcal']}}" data-carbs="{{food['carbs']}}" data-protein="{{food['protein']}}" data-fat="{{food['fat']}}">{{food['name']}}</option>
+{% endfor %}
+</select></td>
+<td><input name="new_gram_{{day}}_{{meal}}_1" type="number" class="form-control gram-input"></td>
+<td class="kcal"></td>
+<td class="carbs"></td>
+<td class="protein"></td>
+<td class="fat"></td>
+<td></td>
 </tr>
 </table>
+<button class="btn btn-sm btn-secondary mb-3" type="button" onclick="addRow('{{day}}','{{meal}}')">Aggiungi riga</button>
 {% endfor %}
 </div>
 {% endfor %}
@@ -44,4 +55,44 @@
 <button class="btn btn-primary mt-2" type="submit">Salva</button>
 <a class="btn btn-secondary mt-2" href="/patient/{{ patient['id'] }}">Torna</a>
 </form>
+<template id="foodOptions">
+<option value="">--</option>
+{% for food in foods %}
+<option value="{{food['id']}}" data-kcal="{{food['kcal']}}" data-carbs="{{food['carbs']}}" data-protein="{{food['protein']}}" data-fat="{{food['fat']}}">{{food['name']}}</option>
+{% endfor %}
+</template>
+<script>
+function calcRow(row){
+    const sel = row.querySelector('.food-select');
+    const grams = parseFloat(row.querySelector('.gram-input').value) || 0;
+    const opt = sel.options[sel.selectedIndex];
+    const kcal = parseFloat(opt.dataset.kcal||0);
+    const carbs = parseFloat(opt.dataset.carbs||0);
+    const pro = parseFloat(opt.dataset.protein||0);
+    const fat = parseFloat(opt.dataset.fat||0);
+    row.querySelector('.kcal').textContent = ((kcal*grams)/100).toFixed(1);
+    row.querySelector('.carbs').textContent = ((carbs*grams)/100).toFixed(1);
+    row.querySelector('.protein').textContent = ((pro*grams)/100).toFixed(1);
+    row.querySelector('.fat').textContent = ((fat*grams)/100).toFixed(1);
+}
+document.querySelectorAll('.food-select, .gram-input').forEach(el=>{
+    el.addEventListener('change', e=>calcRow(e.target.closest('tr')));
+    el.addEventListener('input', e=>calcRow(e.target.closest('tr')));
+    calcRow(el.closest('tr'));
+});
+function addRow(day, meal){
+    const table = document.getElementById(`tbl_${day}_${meal}`);
+    const idx = table.querySelectorAll('tr.new-row').length + 1;
+    const temp = document.createElement('tr');
+    temp.className = 'new-row';
+    temp.innerHTML = `<td><select name="new_food_${day}_${meal}_${idx}" class="form-select food-select">${document.getElementById('foodOptions').innerHTML}</select></td>`+
+                     `<td><input name="new_gram_${day}_${meal}_${idx}" type="number" class="form-control gram-input"></td>`+
+                     '<td class="kcal"></td><td class="carbs"></td><td class="protein"></td><td class="fat"></td><td></td>';
+    table.appendChild(temp);
+    temp.querySelectorAll('.food-select, .gram-input').forEach(el=>{
+        el.addEventListener('change',()=>calcRow(temp));
+        el.addEventListener('input',()=>calcRow(temp));
+    });
+}
+</script>
 {% endblock %}

--- a/templates/patient_detail.html
+++ b/templates/patient_detail.html
@@ -20,22 +20,35 @@
 <div class="col-md-8">
 <h4>Visite</h4>
 <table class="table table-sm">
-<tr><th>Data</th><th>Azioni</th></tr>
+<tr><th>Data</th></tr>
 {% for v in visits %}
 <tr>
-<td>{{v['date']}}</td>
-<td><a class="btn btn-sm btn-info" href="/patient/{{patient['id']}}/visit/{{v['id']}}">Mostra</a></td>
+<td><a href="/patient/{{patient['id']}}?visit={{v['id']}}">{{v['date']}}</a></td>
 </tr>
 {% endfor %}
 </table>
-{% if visit %}
-<h4>Dettaglio visita {{ visit['date'] }}</h4>
-<form method="post" action="/patient/{{patient['id']}}/visit/{{visit['id']}}/edit">
-<textarea name="notes" class="form-control" rows="10">{{ visit['notes'] }}</textarea>
-<button class="btn btn-primary mt-2" type="submit">Aggiorna</button>
-</form>
+<h4>Piano Nutrizionale</h4>
+{% if goals %}
+<ul class="list-unstyled">
+  <li>Calorie: {{ goals['calories'] }}</li>
+  <li>CHO %: {{ goals['cho_percent'] }}</li>
+  <li>PRO %: {{ goals['pro_percent'] }}</li>
+  <li>FAT %: {{ goals['fat_percent'] }}</li>
+</ul>
+{% else %}
+<p>Nessun obiettivo impostato</p>
 {% endif %}
+<a class="btn btn-sm btn-primary" href="/patient/{{patient['id']}}/meal_plan">Apri piano</a>
+<a class="btn btn-sm btn-secondary" href="/patient/{{patient['id']}}/goals">Obiettivi</a>
 </div>
 </div>
+{% if visit %}
+<div class="row mt-4">
+<div class="col">
+<h4>Dettaglio visita {{ visit['date'] }}</h4>
+<div class="border p-2" style="white-space:pre-wrap">{{ visit['notes']|safe }}</div>
+</div>
+</div>
+{% endif %}
 <a class="btn btn-secondary mt-2" href="/">Indietro</a>
 {% endblock %}

--- a/templates/visit_form.html
+++ b/templates/visit_form.html
@@ -3,11 +3,18 @@
 <h1>Nuova visita</h1>
 <form method="post">
 <div class="mb-2"><label>Data</label><input type="date" name="date" class="form-control" value="{{today}}"></div>
-<h3>Note precedenti</h3>
-<div class="mb-3 border p-2">{{ last_notes|safe }}</div>
-<h3>Nuove note</h3>
-<div id="notes">
-<div class="mb-2"><input name="title1" class="form-control mb-1" placeholder="Titolo"><textarea name="desc1" class="form-control" placeholder="Descrizione"></textarea></div>
+<div class="row">
+  <div class="col-md-6">
+    <h3>Nuove note</h3>
+    <div id="notes">
+      <div class="mb-2"><input name="title1" class="form-control mb-1" placeholder="Titolo"><textarea name="desc1" class="form-control" placeholder="Descrizione"></textarea></div>
+    </div>
+    <button class="btn btn-sm btn-secondary mt-2" type="button" onclick="addNote()">Aggiungi nota</button>
+  </div>
+  <div class="col-md-6">
+    <h3>Note precedenti</h3>
+    <div class="mb-3 border p-2" style="min-height:100px;">{{ last_notes|safe }}</div>
+  </div>
 </div>
 <h3>Misure</h3>
 <div class="row g-2">
@@ -18,4 +25,15 @@
 <button class="btn btn-primary mt-2" type="submit">Salva</button>
 <a class="btn btn-secondary mt-2" href="/">Annulla</a>
 </form>
+<script>
+let noteIdx = 2;
+function addNote() {
+  const container = document.getElementById('notes');
+  const div = document.createElement('div');
+  div.className = 'mb-2';
+  div.innerHTML = `<input name="title${noteIdx}" class="form-control mb-1" placeholder="Titolo"><textarea name="desc${noteIdx}" class="form-control" placeholder="Descrizione"></textarea>`;
+  container.appendChild(div);
+  noteIdx++;
+}
+</script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- remove before_first_request `setup` wrapper
- initialize the database in the `__main__` block
- clean up patient detail view and show goals & meal plan
- show visit details inline and drop extra route
- allow adding multiple notes when creating a visit
- display visit notes read-only and link to goals form
- add goals form and dynamic meal plan editing

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_684c8a1d535c832485cf2257ecc9c6c5