### PR TITLE
Improve meal plan UI with goals summary

### DIFF
--- a/templates/goals_form.html
+++ b/templates/goals_form.html
@@ -9,16 +9,39 @@
   <div class="mb-2">
     <label class="form-label">CHO %</label>
     <input name="cho_percent" type="number" step="0.1" class="form-control" value="{{ goals['cho_percent'] if goals else '' }}">
+    <input id="cho_g" class="form-control mt-1" readonly>
   </div>
   <div class="mb-2">
     <label class="form-label">PRO %</label>
     <input name="pro_percent" type="number" step="0.1" class="form-control" value="{{ goals['pro_percent'] if goals else '' }}">
+    <input id="pro_g" class="form-control mt-1" readonly>
   </div>
   <div class="mb-2">
     <label class="form-label">FAT %</label>
     <input name="fat_percent" type="number" step="0.1" class="form-control" value="{{ goals['fat_percent'] if goals else '' }}">
+    <input id="fat_g" class="form-control mt-1" readonly>
   </div>
   <button class="btn btn-primary">Salva</button>
   <a class="btn btn-secondary" href="/patient/{{ patient_id }}">Annulla</a>
 </form>
+<script>
+function updateGrams() {
+  const kcal = parseFloat(document.querySelector('[name=calories]').value) || 0;
+  const choP = parseFloat(document.querySelector('[name=cho_percent]').value) || 0;
+  const proP = parseFloat(document.querySelector('[name=pro_percent]').value) || 0;
+  const fatP = parseFloat(document.querySelector('[name=fat_percent]').value) || 0;
+  document.getElementById('cho_g').value = (kcal * choP / 100 / 4).toFixed(1);
+  document.getElementById('pro_g').value = (kcal * proP / 100 / 4).toFixed(1);
+  document.getElementById('fat_g').value = (kcal * fatP / 100 / 9).toFixed(1);
+}
+updateGrams();
+document.querySelectorAll('input').forEach(i => i.addEventListener('input', updateGrams));
+document.querySelector('form').addEventListener('submit', function(e){
+  const total = ['cho_percent','pro_percent','fat_percent'].reduce((s,n)=>s+parseFloat(document.querySelector('[name='+n+']').value||0),0);
+  if (Math.round(total*10)/10 !== 100) {
+    e.preventDefault();
+    alert('La somma delle percentuali deve essere 100');
+  }
+});
+</script>
 {% endblock %}

--- a/templates/meal_plan.html
+++ b/templates/meal_plan.html
@@ -2,6 +2,8 @@
 {% block content %}
 <h1>Piano Nutrizionale {{ patient['name'] }}</h1>
 <form method="post">
+<div class="row">
+<div class="col-md-9">
 <ul class="nav nav-tabs" id="dayTabs" role="tablist">
 {% for day in days %}
 <li class="nav-item" role="presentation">
@@ -11,10 +13,11 @@
 </ul>
 <div class="tab-content border p-3">
 {% for day in days %}
-<div class="tab-pane fade {% if loop.first %}show active{% endif %}" id="tab{{loop.index}}">
+<div class="tab-pane fade {% if loop.first %}show active{% endif %}" id="tab{{loop.index}}" data-day="{{day}}">
+<div class="text-end mb-2 day-summary"></div>
 {% for meal in meals %}
 <h5>{{ meal }}</h5>
-<table class="table table-sm">
+<table class="table table-sm" data-meal="{{meal}}">
 <tr><th>Alimento</th><th>Gr</th><th>Kcal</th><th>CHO</th><th>PRO</th><th>FAT</th><th></th></tr>
 {% for row in plan[(day,meal)] %}
 <tr>
@@ -33,12 +36,15 @@
 </tr>
 {% endfor %}
 <tr class="add-row">
-<td><select name="food_{{day}}_{{meal}}[]" class="form-select">
-<option value="">--</option>
-{% for food in foods %}
-<option value="{{food['id']}}" data-kcal="{{food['kcal']}}" data-carbs="{{food['carbs']}}" data-protein="{{food['protein']}}" data-fat="{{food['fat']}}">{{food['name']}}</option>
-{% endfor %}
-</select></td>
+<td>
+  <input type="text" class="form-control form-control-sm food-search mb-1" placeholder="Filtra">
+  <select name="food_{{day}}_{{meal}}[]" class="form-select">
+  <option value="">--</option>
+  {% for food in foods %}
+  <option value="{{food['id']}}" data-kcal="{{food['kcal']}}" data-carbs="{{food['carbs']}}" data-protein="{{food['protein']}}" data-fat="{{food['fat']}}">{{food['name']}} ({{food['kcal']}}kcal C{{food['carbs']}} P{{food['protein']}} F{{food['fat']}})</option>
+  {% endfor %}
+  </select>
+</td>
 <td><input name="gram_{{day}}_{{meal}}[]" class="form-control"></td>
 <td class="kcal"></td>
 <td class="carbs"></td>
@@ -47,21 +53,30 @@
 <td></td>
 </tr>
 <tr><td colspan="7"><button type="button" class="btn btn-sm btn-secondary" onclick="addRow(this)">Aggiungi riga</button></td></tr>
+<tr class="meal-summary"><td colspan="7" class="text-end small"></td></tr>
 </table>
 {% endfor %}
 </div>
 {% endfor %}
 </div>
+</div>
+<div class="col-md-3">
+  <div id="goal-summary" class="border p-2"></div>
+</div>
+</div>
 <button class="btn btn-primary mt-2" type="submit">Salva</button>
 <a class="btn btn-secondary mt-2" href="/patient/{{ patient['id'] }}">Torna</a>
 </form>
 <script>
+const goals = {{ goals|tojson }};
 function addRow(btn) {
   const table = btn.closest('table');
   const row = table.querySelector('tr.add-row');
   const clone = row.cloneNode(true);
   clone.querySelectorAll('input').forEach(i => i.value = '');
+  clone.querySelector('select').selectedIndex = 0;
   table.insertBefore(clone, btn.closest('tr'));
+  setupFilter(clone);
   updateMacros(clone);
 }
 function updateMacros(row) {
@@ -76,6 +91,7 @@ function updateMacros(row) {
   row.querySelector('.carbs').textContent = carbs ? carbs.toFixed(1) : '';
   row.querySelector('.protein').textContent = pro ? pro.toFixed(1) : '';
   row.querySelector('.fat').textContent = fat ? fat.toFixed(1) : '';
+  computeTotals();
 }
 document.addEventListener('input', e => {
   if (e.target.matches('tr.add-row input')) {
@@ -87,5 +103,51 @@ document.addEventListener('change', e => {
     updateMacros(e.target.closest('tr'));
   }
 });
+function setupFilter(row) {
+  const inp = row.querySelector('.food-search');
+  if (!inp) return;
+  const sel = row.querySelector('select');
+  inp.addEventListener('input', () => {
+    const f = inp.value.toLowerCase();
+    for (const opt of sel.options) {
+      opt.style.display = opt.text.toLowerCase().includes(f) ? '' : 'none';
+    }
+  });
+}
+function computeTotals() {
+  document.querySelectorAll('.tab-pane').forEach(pane => {
+    let dayTot = {kcal:0,carbs:0,protein:0,fat:0};
+    pane.querySelectorAll('table').forEach(table => {
+      let mealTot = {kcal:0,carbs:0,protein:0,fat:0};
+      table.querySelectorAll('tr.add-row').forEach(row => {
+        mealTot.kcal += parseFloat(row.querySelector('.kcal').textContent)||0;
+        mealTot.carbs += parseFloat(row.querySelector('.carbs').textContent)||0;
+        mealTot.protein += parseFloat(row.querySelector('.protein').textContent)||0;
+        mealTot.fat += parseFloat(row.querySelector('.fat').textContent)||0;
+      });
+      dayTot.kcal += mealTot.kcal;
+      dayTot.carbs += mealTot.carbs;
+      dayTot.protein += mealTot.protein;
+      dayTot.fat += mealTot.fat;
+      const mrow = table.querySelector('.meal-summary td');
+      if (mrow) {
+        mrow.textContent = `Totale: ${mealTot.kcal.toFixed(1)} kcal CHO ${mealTot.carbs.toFixed(1)}g PRO ${mealTot.protein.toFixed(1)}g FAT ${mealTot.fat.toFixed(1)}g`;
+      }
+    });
+    const dsum = pane.querySelector('.day-summary');
+    if (dsum) {
+      dsum.textContent = `Totale giorno: ${dayTot.kcal.toFixed(1)} kcal CHO ${dayTot.carbs.toFixed(1)}g PRO ${dayTot.protein.toFixed(1)}g FAT ${dayTot.fat.toFixed(1)}g`;
+    }
+  });
+  const active = document.querySelector('.tab-pane.active');
+  if (active) {
+    document.getElementById('goal-summary').innerHTML =
+      `<div><b>Obiettivi:</b> ${goals.calories} kcal CHO ${goals.cho_g.toFixed(1)}g PRO ${goals.pro_g.toFixed(1)}g FAT ${goals.fat_g.toFixed(1)}g</div>` +
+      `<div>${active.querySelector('.day-summary').textContent}</div>`;
+  }
+}
+document.querySelectorAll('tr.add-row').forEach(setupFilter);
+computeTotals();
+document.getElementById('dayTabs').addEventListener('shown.bs.tab', computeTotals);
 </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- compute meal plan totals per day and per meal
- show goals and day summary side panel
- make food dropdown searchable and show macros
- convert goal percentages to grams with validation

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_684c94c43d588324a551968d351ffef2