### PR TITLE
Add save/back buttons at top of meal plan

### DIFF
--- a/templates/meal_plan.html
+++ b/templates/meal_plan.html
@@ -2,6 +2,10 @@
 {% block content %}
 <h1>Piano Nutrizionale {{ patient['name'] }}</h1>
 <form method="post">
+<div class="mb-2 text-end">
+  <button class="btn btn-primary" type="submit">Salva</button>
+  <a class="btn btn-secondary" href="/patient/{{ patient['id'] }}">Torna</a>
+</div>
 <datalist id="foodsList">
   {% for food in foods %}
   <option value="{{food['name']}}" data-id="{{food['id']}}" data-kcal="{{food['kcal']}}" data-carbs="{{food['carbs']}}" data-protein="{{food['protein']}}" data-fat="{{food['fat']}}"></option>


### PR DESCRIPTION
## Summary
- show Save and Back buttons at the top of the meal plan form

## Testing
- `python -m py_compile app.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68508f3292208324ac94e5dc75d3fb15