### PR TITLE
Enhance foods usability

### DIFF
--- a/app.py
+++ b/app.py
@@ -113,29 +113,36 @@ def del_question(qid):
 
 @app.route('/foods')
 def foods():
+    back = request.args.get('back', '/')
     con = get_db()
     fs = con.execute('SELECT * FROM foods ORDER BY name').fetchall()
     con.close()
-    return render_template('foods.html', foods=fs)
+    return render_template('foods.html', foods=fs, back=back)
 
 
 @app.route('/foods/add', methods=['POST'])
 def add_food():
+    back = request.form.get('back')
     con = get_db()
     con.execute('INSERT INTO foods (name, kcal, carbs, protein, fat) VALUES (?,?,?,?,?)',
                 (request.form['name'], request.form.get('kcal'), request.form.get('carbs'),
                  request.form.get('protein'), request.form.get('fat')))
     con.commit()
     con.close()
+    if back:
+        return redirect(url_for('foods', back=back))
     return redirect(url_for('foods'))
 
 
 @app.route('/foods/delete/<int:fid>', methods=['POST'])
 def del_food(fid):
+    back = request.form.get('back')
     con = get_db()
     con.execute('DELETE FROM foods WHERE id=?', (fid,))
     con.commit()
     con.close()
+    if back:
+        return redirect(url_for('foods', back=back))
     return redirect(url_for('foods'))
 
 
@@ -314,8 +321,10 @@ def meal_plan(pid):
             d[key] += r[key]
             m[key] += r[key]
     con.close()
+    foods_url = url_for('foods', back=url_for('meal_plan', pid=pid))
     return render_template('meal_plan.html', patient=patient, days=DAYS, meals=MEALS,
-                           foods=foods, plan=plan, goals=goals_grams, summary=summary)
+                           foods=foods, plan=plan, goals=goals_grams, summary=summary,
+                           foods_url=foods_url)
 
 
 @app.route('/patient/<int:pid>/meal_plan/delete/<int:mid>', methods=['POST'])

--- a/templates/foods.html
+++ b/templates/foods.html
@@ -1,28 +1,46 @@
 {% extends 'base.html' %}
 {% block content %}
 <h1>Alimenti</h1>
-<form method="post" class="mb-3" action="/foods/add">
-<div class="row g-2">
-<div class="col"><input name="name" class="form-control" placeholder="Nome" required></div>
-<div class="col"><input name="kcal" class="form-control" placeholder="Kcal" type="number" step="0.1"></div>
-<div class="col"><input name="carbs" class="form-control" placeholder="CHO" type="number" step="0.1"></div>
-<div class="col"><input name="protein" class="form-control" placeholder="PRO" type="number" step="0.1"></div>
-<div class="col"><input name="fat" class="form-control" placeholder="FAT" type="number" step="0.1"></div>
-<div class="col"><button class="btn btn-primary">Aggiungi</button></div>
+<div class="mb-2 text-end">
+  <a class="btn btn-secondary" href="{{ back }}">Torna</a>
 </div>
+<form method="post" class="mb-3" action="/foods/add">
+  <input type="hidden" name="back" value="{{ back }}">
+  <div class="row g-2">
+    <div class="col"><input name="name" class="form-control" placeholder="Nome" required></div>
+    <div class="col"><input name="kcal" class="form-control" placeholder="Kcal" type="number" step="0.1"></div>
+    <div class="col"><input name="carbs" class="form-control" placeholder="CHO" type="number" step="0.1"></div>
+    <div class="col"><input name="protein" class="form-control" placeholder="PRO" type="number" step="0.1"></div>
+    <div class="col"><input name="fat" class="form-control" placeholder="FAT" type="number" step="0.1"></div>
+    <div class="col"><button class="btn btn-primary">Aggiungi</button></div>
+  </div>
 </form>
-<table class="table table-striped">
+<input id="food-filter" class="form-control mb-2" placeholder="Filtra...">
+<table class="table table-striped" id="foods-table">
 <tr><th>Nome</th><th>Kcal</th><th>CHO</th><th>PRO</th><th>FAT</th><th>Azioni</th></tr>
 {% for f in foods %}
 <tr>
 <td>{{f['name']}}</td><td>{{f['kcal']}}</td><td>{{f['carbs']}}</td><td>{{f['protein']}}</td><td>{{f['fat']}}</td>
 <td>
 <form method="post" action="/foods/delete/{{f['id']}}" style="display:inline">
-<button class="btn btn-danger btn-sm">Elimina</button>
+  <input type="hidden" name="back" value="{{ back }}">
+  <button class="btn btn-danger btn-sm">Elimina</button>
 </form>
 </td>
 </tr>
 {% endfor %}
 </table>
-<a class="btn btn-secondary" href="/">Torna</a>
+<div class="text-end">
+  <a class="btn btn-secondary" href="{{ back }}">Torna</a>
+</div>
+<script>
+function applyFilter() {
+  const val = document.getElementById('food-filter').value.toLowerCase();
+  document.querySelectorAll('#foods-table tbody tr').forEach(row => {
+    const name = row.querySelector('td').textContent.toLowerCase();
+    row.style.display = name.includes(val) ? '' : 'none';
+  });
+}
+document.getElementById('food-filter').addEventListener('input', applyFilter);
+</script>
 {% endblock %}

--- a/templates/meal_plan.html
+++ b/templates/meal_plan.html
@@ -4,6 +4,7 @@
 <form method="post">
 <div class="mb-2 text-end">
   <button class="btn btn-primary" type="submit">Salva</button>
+  <a class="btn btn-secondary" href="{{ foods_url }}">Alimenti</a>
   <a class="btn btn-secondary" href="/patient/{{ patient['id'] }}">Torna</a>
 </div>
 <datalist id="foodsList">


### PR DESCRIPTION
## Summary
- keep alphabetical foods listing
- allow redirect back to meal plan when leaving the foods page
- add filtering for foods list
- provide button to open foods from meal plan

## Testing
- `python3 -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_685097cb42848324a302f083970b183a