### PR TITLE
Implement attachments management

### DIFF
--- a/templates/attachments.html
+++ b/templates/attachments.html
@@ -1,0 +1,25 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>Allegati {{ patient['name'] }}</h1>
+<form method="post" enctype="multipart/form-data" class="mb-3">
+  <div class="input-group">
+    <input type="file" name="file" class="form-control" required>
+    <button class="btn btn-primary" type="submit">Carica</button>
+  </div>
+</form>
+<table class="table table-sm">
+  <tr><th>Nome</th><th>Caricato il</th><th></th></tr>
+  {% for a in attachments %}
+  <tr>
+    <td><a href="{{ url_for('download_attachment', aid=a['id']) }}">{{ a['filename'] }}</a></td>
+    <td>{{ a['upload_date'] }}</td>
+    <td>
+      <form method="post" action="{{ url_for('delete_attachment', aid=a['id']) }}" style="display:inline">
+        <button class="btn btn-sm btn-danger">Elimina</button>
+      </form>
+    </td>
+  </tr>
+  {% endfor %}
+</table>
+<a class="btn btn-secondary" href="/patient/{{ patient['id'] }}">Torna</a>
+{% endblock %}

--- a/templates/patient_detail.html
+++ b/templates/patient_detail.html
@@ -39,6 +39,7 @@
 {% endif %}
 <a class="btn btn-sm btn-primary" href="/patient/{{patient['id']}}/meal_plan">Apri piano</a>
 <a class="btn btn-sm btn-secondary" href="/patient/{{patient['id']}}/goals">Obiettivi</a>
+<a class="btn btn-sm btn-secondary" href="/patient/{{patient['id']}}/attachments">Allegati</a>
 <h4>Visite</h4>
 <table class="table table-sm">
 <tr><th>Data</th></tr>


### PR DESCRIPTION
## Summary
- add backend logic for patient attachments
- provide attachments upload and management page
- link to attachments from patient detail page
- keep a directory to store uploaded files

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_68546114697883249ccb02283688247a