### PR TITLE
Add configurable data directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+# Ignore user-specific configuration
+config.ini
+
+# Ignore runtime data
+nutrigest.db
+attachments/
+__pycache__/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,7 @@
+# Nutrigest
+
+This application stores its database and uploaded attachments in a directory
+specified by `config.ini`.
+
+Create a `config.ini` file based on the provided `config.ini.example` and set the
+`data_dir` path to the folder where you want these files stored.

--- a/app.py
+++ b/app.py
@@ -1,13 +1,23 @@
 import sqlite3
 import os
 import time
+import configparser
 from flask import Flask, render_template, request, redirect, url_for, send_from_directory
 from datetime import date
 from werkzeug.utils import secure_filename
 
 app = Flask(__name__)
-DB = 'nutrigest.db'
-ATTACH_FOLDER = 'attachments'
+
+# Load configuration
+config = configparser.ConfigParser()
+config.read('config.ini')
+DATA_DIR = config.get('Paths', 'data_dir', fallback='.')
+
+# Paths for database and attachments
+DB = os.path.join(DATA_DIR, 'nutrigest.db')
+ATTACH_FOLDER = os.path.join(DATA_DIR, 'attachments')
+
+# Ensure directories exist
 os.makedirs(ATTACH_FOLDER, exist_ok=True)
 
 

--- a/config.ini.example
+++ b/config.ini.example
@@ -1,0 +1,6 @@
+[Paths]
+# Directory where the database and attachments will be stored
+# Example: data
+# data_dir = /path/to/storage
+
+data_dir = data


### PR DESCRIPTION
## Summary
- allow configuring database and attachment storage paths through a `config.ini`
- provide sample `config.ini.example`
- ignore runtime data and user config
- add a short README

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6854715552488324a06465e8058324e0