### PR TITLE
Add Nutriflap rename and folder change feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,6 @@
 config.ini
 
 # Ignore runtime data
-nutrigest.db
+nutriflap.db
 attachments/
 __pycache__/

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Nutrigest
+# Nutriflap
 
 This application stores its database and uploaded attachments in a directory
 specified by `config.ini`.

--- a/templates/base.html
+++ b/templates/base.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="utf-8">
-    <title>NutriGest</title>
+    <title>Nutriflap</title>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.0/dist/flatly/bootstrap.min.css">
     <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
 </head>
@@ -11,8 +11,9 @@
     <div class="container-fluid">
         <a class="navbar-brand d-flex align-items-center" href="{{ url_for('index') }}">
             <img src="{{ url_for('static', filename='logo.png') }}" alt="Logo" style="height:40px;" class="me-2">
-            <span>NutriGest</span>
+            <span>Nutriflap</span>
         </a>
+        <a class="text-white" href="{{ url_for('change_data_dir') }}" title="Opzioni">&#9881;</a>
     </div>
 </nav>
 <div class="container mt-1">


### PR DESCRIPTION
## Summary
- rename project references to Nutriflap
- add gear icon in navbar
- allow user to change storage folder, copying database and attachments
- database now named `nutriflap.db`

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68547b2cdde883249f4c633b909f5fcf