### PR TITLE
Include DB in PyInstaller build and auto-launch browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,18 @@ specified by `config.ini`.
 
 Create a `config.ini` file based on the provided `config.ini.example` and set the
 `data_dir` path to the folder where you want these files stored.
+
+## Building a standalone executable
+
+To package the application with PyInstaller use:
+
+```bash
+pyinstaller --noconfirm --onefile \
+  --add-data "templates;templates" \
+  --add-data "static;static" \
+  --add-data "init_db.sql;." \
+  --add-data "nutriflap.db;." app.py
+```
+
+The resulting executable will include the default database and, when run,
+automatically open your browser to `http://127.0.0.1:5000/`.

--- a/app.py
+++ b/app.py
@@ -8,6 +8,8 @@ from flask import Flask, render_template, request, redirect, url_for, send_from_
 from datetime import date
 from werkzeug.utils import secure_filename
 from tkinter import Tk, filedialog, messagebox
+import threading
+import webbrowser
 
 app = Flask(__name__)
 
@@ -568,4 +570,9 @@ def delete_patient(pid):
 
 if __name__ == '__main__':
     init_db()
+
+    def open_browser():
+        webbrowser.open_new('http://127.0.0.1:5000/')
+
+    threading.Timer(1.0, open_browser).start()
     app.run(debug=False)


### PR DESCRIPTION
## Summary
- open default browser automatically when the app starts
- document PyInstaller usage, including bundling the default database

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6855b4f260dc8324afac797b6b09a3c5