### PR TITLE
Fix license file path for packaged builds

### DIFF
--- a/app.py
+++ b/app.py
@@ -16,7 +16,10 @@ import webbrowser
 
 app = Flask(__name__)
 
-BASE_PATH = os.path.dirname(os.path.abspath(__file__))
+if getattr(sys, 'frozen', False):
+    BASE_PATH = os.path.dirname(sys.executable)
+else:
+    BASE_PATH = os.path.dirname(os.path.abspath(__file__))
 LICENSE_FILE = os.path.join(BASE_PATH, 'license')
 API_URL = 'https://script.google.com/macros/s/AKfycbySf389gYwY0Enq8mXOyqr9iZiIz5kMyup9acIpB8JNRU8MwVgvXtAM4wl9CAUxprNdxQ/exec'
 API_KEY = 'asdnsiadnoienoiniopwefiefnw'


### PR DESCRIPTION
## Summary
- adjust BASE_PATH logic so the license file is written next to the executable when frozen with PyInstaller

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_6855cda04a0883248c8c2d2a960c6e06