### PR TITLE
Fix license path when packaged

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,7 @@ pyinstaller --noconfirm --onefile --noconsole \
 
 The resulting executable will include the default database and, when run,
 automatically open your browser to `http://127.0.0.1:5000/`.
+
+When packaged, the application writes the `license` file in the same folder
+as the executable. Make sure the user has write permissions in that
+directory when running the `.exe`.

--- a/app.py
+++ b/app.py
@@ -16,7 +16,10 @@ import webbrowser
 
 app = Flask(__name__)
 
-BASE_PATH = os.path.dirname(os.path.abspath(__file__))
+if getattr(sys, 'frozen', False):
+    BASE_PATH = os.path.dirname(sys.executable)
+else:
+    BASE_PATH = os.path.dirname(os.path.abspath(__file__))
 LICENSE_FILE = os.path.join(BASE_PATH, 'license')
 API_URL = 'https://script.google.com/macros/s/AKfycbySf389gYwY0Enq8mXOyqr9iZiIz5kMyup9acIpB8JNRU8MwVgvXtAM4wl9CAUxprNdxQ/exec'
 API_KEY = 'asdnsiadnoienoiniopwefiefnw'


### PR DESCRIPTION
## Summary
- ensure license file is written next to executable when app is frozen
- document license file location in README

## Testing
- `python -m py_compile app.py`
- `flake8 app.py` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855cefb7a3883248c439c26c8c4a1d7