### PR TITLE
Add separate surname and gender for patients

### DIFF
--- a/templates/attachments.html
+++ b/templates/attachments.html
@@ -1,6 +1,6 @@
 {% extends 'base.html' %}
 {% block content %}
-<h1 class="mb-3">Allegati {{ patient['name'] }}</h1>
+<h1 class="mb-3">Allegati {{ patient['name'] }} {{ patient['surname'] }}</h1>
 <div class="card p-3 mb-3">
 <form method="post" enctype="multipart/form-data" class="mb-3">
   <div class="input-group">

--- a/templates/edit_patient.html
+++ b/templates/edit_patient.html
@@ -3,9 +3,23 @@
 <h1 class="mb-3">Modifica Paziente</h1>
 <div class="card p-3">
 <form method="post">
+<div class="row">
+  <div class="col mb-2">
+    <label class="form-label">Nome</label>
+    <input name="name" class="form-control" value="{{ patient['name'] }}" required>
+  </div>
+  <div class="col mb-2">
+    <label class="form-label">Cognome</label>
+    <input name="surname" class="form-control" value="{{ patient['surname'] }}" required>
+  </div>
+</div>
 <div class="mb-2">
-<label class="form-label">Nome e Cognome</label>
-<input name="name" class="form-control" value="{{ patient['name'] }}" required>
+<label class="form-label">Sesso</label>
+<select name="gender" class="form-select">
+  <option value="" {% if not patient['gender'] %}selected{% endif %}>-</option>
+  <option value="M" {% if patient['gender']=='M' %}selected{% endif %}>Maschio</option>
+  <option value="F" {% if patient['gender']=='F' %}selected{% endif %}>Femmina</option>
+</select>
 </div>
 <div class="mb-2">
 <label class="form-label">Codice Fiscale</label>

--- a/templates/index.html
+++ b/templates/index.html
@@ -10,9 +10,11 @@
     <thead>
     <tr>
         <th>Nome<br><input class="form-control form-control-sm filter" data-col="0"></th>
-        <th>Nascita<br><input class="form-control form-control-sm filter" data-col="1"></th>
-        <th>Email<br><input class="form-control form-control-sm filter" data-col="2"></th>
-        <th>Telefono<br><input class="form-control form-control-sm filter" data-col="3"></th>
+        <th>Cognome<br><input class="form-control form-control-sm filter" data-col="1"></th>
+        <th>Nascita<br><input class="form-control form-control-sm filter" data-col="2"></th>
+        <th>Sesso<br><input class="form-control form-control-sm filter" data-col="3"></th>
+        <th>Email<br><input class="form-control form-control-sm filter" data-col="4"></th>
+        <th>Telefono<br><input class="form-control form-control-sm filter" data-col="5"></th>
         <th>Azioni</th>
     </tr>
     </thead>
@@ -20,7 +22,9 @@
     {% for p in patients %}
     <tr>
         <td>{{ p['name'] }}</td>
+        <td>{{ p['surname'] }}</td>
         <td>{{ p['birthdate'] or '' }}</td>
+        <td>{{ p['gender'] or '' }}</td>
         <td>{{ p['email'] or '' }}</td>
         <td>{{ p['phone'] or '' }}</td>
         <td>

--- a/templates/meal_plan.html
+++ b/templates/meal_plan.html
@@ -1,6 +1,6 @@
 {% extends 'base.html' %}
 {% block content %}
-<h1 class="mb-3">Piano Nutrizionale {{ patient['name'] }}</h1>
+<h1 class="mb-3">Piano Nutrizionale {{ patient['name'] }} {{ patient['surname'] }}</h1>
 <div class="card p-3">
 <form method="post">
 <div class="mb-2 text-end">

--- a/templates/new_patient.html
+++ b/templates/new_patient.html
@@ -3,9 +3,23 @@
 <h1 class="mb-3">Nuovo Paziente</h1>
 <div class="card p-3">
 <form method="post">
+<div class="row">
+  <div class="col mb-2">
+    <label class="form-label">Nome</label>
+    <input name="name" class="form-control" required>
+  </div>
+  <div class="col mb-2">
+    <label class="form-label">Cognome</label>
+    <input name="surname" class="form-control" required>
+  </div>
+</div>
 <div class="mb-2">
-<label class="form-label">Nome e Cognome</label>
-<input name="name" class="form-control" required>
+<label class="form-label">Sesso</label>
+<select name="gender" class="form-select">
+  <option value="">-</option>
+  <option value="M">Maschio</option>
+  <option value="F">Femmina</option>
+</select>
 </div>
 <div class="mb-2">
 <label class="form-label">Codice Fiscale</label>

--- a/templates/patient_delete_confirm.html
+++ b/templates/patient_delete_confirm.html
@@ -2,7 +2,7 @@
 {% block content %}
 <h1 class="mb-3 text-danger">Elimina Paziente</h1>
 <div class="card p-3">
-<p>Per eliminare definitivamente <strong>{{ patient['name'] }}</strong> digita il suo nome e cognome e conferma.</p>
+<p>Per eliminare definitivamente <strong>{{ patient['name'] }} {{ patient['surname'] }}</strong> digita il suo nome e cognome e conferma.</p>
 {% if error %}<div class="alert alert-danger">{{ error }}</div>{% endif %}
 <form method="post">
   <input name="confirm_name" class="form-control mb-3" placeholder="Nome Cognome" required>

--- a/templates/patient_detail.html
+++ b/templates/patient_detail.html
@@ -1,6 +1,6 @@
 {% extends 'base.html' %}
 {% block content %}
-<h1 class="mb-3">{{ patient['name'] }}</h1>
+<h1 class="mb-3">{{ patient['name'] }} {{ patient['surname'] }}</h1>
 <div class="row">
 <div class="col-md-8">
 <div class="card p-3 mb-3">

--- a/templates/visit_form.html
+++ b/templates/visit_form.html
@@ -1,6 +1,6 @@
 {% extends 'base.html' %}
 {% block content %}
-<h1 class="mb-3">{% if visit %}Modifica visita{% else %}Nuova visita{% endif %} - {{ patient['name'] }}</h1>
+<h1 class="mb-3">{% if visit %}Modifica visita{% else %}Nuova visita{% endif %} - {{ patient['name'] }} {{ patient['surname'] }}</h1>
 <div class="card p-3">
 <form method="post">
 <div class="mb-2"><label>Data</label><input type="date" name="date" class="form-control" value="{{ visit['date'] if visit else today }}"></div>


### PR DESCRIPTION
## Summary
- store patient first name and surname separately
- allow selecting patient gender
- show name, surname and gender on patient list
- edit existing patients with the new fields
- update all templates to display the full patient name

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_68570bdff1c48324bd16d2c9df744e01