### PR TITLE
Implement demo license mode

### DIFF
--- a/templates/demo_limit.html
+++ b/templates/demo_limit.html
@@ -1,0 +1,6 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1 class="mb-3">Limite versione demo</h1>
+<p>La chiave demo consente di inserire al massimo 4 pazienti.</p>
+<a class="btn btn-primary" href="{{ url_for('index') }}">Torna alla lista</a>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add `DEMO_KEY` constant and `DEMO_MODE` flag
- allow using a demo license that skips remote check and is stored locally
- enforce demo mode patient limit in `new_patient`
- add a page informing about the demo limit

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_685db4158b5c8324a584040b4848e501